### PR TITLE
Add execute store attribute

### DIFF
--- a/src/main/java/com/github/thedeathlycow/tdcdata/mixin/command/ExecuteStoreAttributeCommandMixin.java
+++ b/src/main/java/com/github/thedeathlycow/tdcdata/mixin/command/ExecuteStoreAttributeCommandMixin.java
@@ -1,0 +1,43 @@
+package com.github.thedeathlycow.tdcdata.mixin.command;
+
+import com.github.thedeathlycow.tdcdata.server.command.ExecuteStoreAttributeCommand;
+import com.mojang.brigadier.arguments.DoubleArgumentType;
+import com.mojang.brigadier.builder.ArgumentBuilder;
+import com.mojang.brigadier.builder.LiteralArgumentBuilder;
+import com.mojang.brigadier.tree.LiteralCommandNode;
+import net.minecraft.command.argument.EntityArgumentType;
+import net.minecraft.command.argument.RegistryKeyArgumentType;
+import net.minecraft.server.command.ExecuteCommand;
+import net.minecraft.server.command.ServerCommandSource;
+import net.minecraft.util.registry.Registry;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import static net.minecraft.server.command.CommandManager.argument;
+import static net.minecraft.server.command.CommandManager.literal;
+@Mixin(ExecuteCommand.class)
+public abstract class ExecuteStoreAttributeCommandMixin {
+
+    @Inject(
+            method="addStoreArguments",
+            at=@At("HEAD")
+    )
+    private static void addAttributeStoreArgument(LiteralCommandNode<ServerCommandSource> node, LiteralArgumentBuilder<ServerCommandSource> builder, boolean requestResult, CallbackInfoReturnable<ArgumentBuilder<ServerCommandSource, ?>> cir){
+        builder.then(literal("attribute").then(
+                argument("target", EntityArgumentType.entity()).then(
+                        argument("attribute", RegistryKeyArgumentType.registryKey(Registry.ATTRIBUTE_KEY)).then(
+                                literal("base").then(
+                                        argument("scale", DoubleArgumentType.doubleArg())
+                                                .redirect(node, context -> ExecuteStoreAttributeCommand.executeStoreAttribute(
+                                                        context.getSource(),
+                                                        EntityArgumentType.getEntity(context, "target"),
+                                                        RegistryKeyArgumentType.getAttribute(context, "attribute"),
+                                                        DoubleArgumentType.getDouble(context, "scale"),
+                                                        requestResult
+                                                ))
+                                )
+                        ))
+        ));
+    }
+}

--- a/src/main/java/com/github/thedeathlycow/tdcdata/server/command/ExecuteStoreAttributeCommand.java
+++ b/src/main/java/com/github/thedeathlycow/tdcdata/server/command/ExecuteStoreAttributeCommand.java
@@ -1,0 +1,32 @@
+package com.github.thedeathlycow.tdcdata.server.command;
+
+import com.mojang.brigadier.ResultConsumer;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.attribute.EntityAttribute;
+import net.minecraft.entity.attribute.EntityAttributeInstance;
+import net.minecraft.server.command.ServerCommandSource;
+import net.minecraft.text.TranslatableText;
+
+import java.util.function.BinaryOperator;
+
+public class ExecuteStoreAttributeCommand {
+    private static final BinaryOperator<ResultConsumer<ServerCommandSource>> BINARY_RESULT_CONSUMER = (resultConsumer, resultConsumer2) -> (context, success, result) -> {
+        resultConsumer.onCommandComplete(context, success, result);
+        resultConsumer2.onCommandComplete(context, success, result);
+    };
+    public static ServerCommandSource executeStoreAttribute(ServerCommandSource source, Entity target, EntityAttribute attribute, double scale, boolean requestResult){
+        return source.mergeConsumers((context, success, result) -> {
+            double value = (requestResult ?  result : (success ? 1 : 0)) * scale;
+            if (target instanceof LivingEntity livingEntity){
+                EntityAttributeInstance inst = livingEntity.getAttributeInstance(attribute);
+                if (inst != null)
+                    inst.setBaseValue(value);
+                else
+                    source.sendError(new TranslatableText("commands.attribute.failed.no_attribute", livingEntity.getName(), new TranslatableText(attribute.getTranslationKey())));
+            }
+            else
+                source.sendError(new TranslatableText("commands.attribute.failed.entity", target.getName()));
+        }, BINARY_RESULT_CONSUMER);
+    }
+}

--- a/src/main/resources/tdcdata.mixins.json
+++ b/src/main/resources/tdcdata.mixins.json
@@ -5,6 +5,7 @@
   "compatibilityLevel": "JAVA_17",
   "mixins": [
     "command.ExecuteIfItemMixin",
+    "command.ExecuteStoreAttributeCommandMixin",
     "command.argument.CustomOperationMixin",
     "predicate.LightPredicateMixin",
     "scoreboard.teamrules.KeepInventoryOnDeathMixin",


### PR DESCRIPTION
Allows the setting of attribute values to command results.
Works by typing `execute store <success|result> attribute <target> base <scale> ...`