### PR TITLE
Game Event advancement criteria

### DIFF
--- a/src/main/java/com/github/thedeathlycow/tdcdata/advancement/PlayerTriggerGameEventCriterion.java
+++ b/src/main/java/com/github/thedeathlycow/tdcdata/advancement/PlayerTriggerGameEventCriterion.java
@@ -20,7 +20,6 @@ public class PlayerTriggerGameEventCriterion extends AbstractCriterion<PlayerTri
 
     @Override
     protected PlayerTriggerGameEventCriterion.Conditions conditionsFromJson(JsonObject json, EntityPredicate.Extended player, AdvancementEntityPredicateDeserializer predicateDeserializer) {
-
         GameEventPredicate eventPredicate = GameEventPredicate.fromJson(json.get("event"));
         return new Conditions(player, eventPredicate);
     }
@@ -49,7 +48,7 @@ public class PlayerTriggerGameEventCriterion extends AbstractCriterion<PlayerTri
         public JsonObject toJson(AdvancementEntityPredicateSerializer predicateSerializer) {
             JsonObject json = super.toJson(predicateSerializer);
             JsonElement eventJson = this.eventPredicate != null ? this.eventPredicate.toJson() : JsonNull.INSTANCE;
-            json.add("event", eventJson);;
+            json.add("event", eventJson);
             return json;
         }
 

--- a/src/main/java/com/github/thedeathlycow/tdcdata/advancement/PlayerTriggerVibrationBlockListener.java
+++ b/src/main/java/com/github/thedeathlycow/tdcdata/advancement/PlayerTriggerVibrationBlockListener.java
@@ -6,7 +6,6 @@ import com.google.gson.JsonNull;
 import com.google.gson.JsonObject;
 import net.minecraft.advancement.criterion.AbstractCriterion;
 import net.minecraft.advancement.criterion.AbstractCriterionConditions;
-import net.minecraft.entity.Entity;
 import net.minecraft.predicate.entity.AdvancementEntityPredicateDeserializer;
 import net.minecraft.predicate.entity.AdvancementEntityPredicateSerializer;
 import net.minecraft.predicate.entity.EntityPredicate;
@@ -19,25 +18,24 @@ import net.minecraft.world.event.GameEvent;
 import org.jetbrains.annotations.Nullable;
 
 
-public class PlayerTriggerVibrationListener extends AbstractCriterion<PlayerTriggerVibrationListener.Conditions> {
+public class PlayerTriggerVibrationBlockListener extends AbstractCriterion<PlayerTriggerVibrationBlockListener.Conditions> {
 
     private final Identifier id;
 
-    public PlayerTriggerVibrationListener(Identifier id) {
+    public PlayerTriggerVibrationBlockListener(Identifier id) {
         this.id = id;
     }
 
     @Override
     protected Conditions conditionsFromJson(JsonObject json, EntityPredicate.Extended player, AdvancementEntityPredicateDeserializer predicateDeserializer) {
         GameEventPredicate eventPredicate = GameEventPredicate.fromJson(json.get("event"));
-        LocationPredicate block = LocationPredicate.fromJson(json.get("listener_block"));
-        EntityPredicate entity = EntityPredicate.fromJson(json.get("listener_entity"));
-        return new Conditions(this.id, player, eventPredicate, block, entity);
+        LocationPredicate block = LocationPredicate.fromJson(json.get("listener"));
+        return new Conditions(this.id, player, eventPredicate, block);
     }
 
-    public void trigger(ServerPlayerEntity player, GameEvent event, ServerWorld world, BlockPos position, @Nullable Entity listener) {
+    public void trigger(ServerPlayerEntity player, GameEvent event, ServerWorld world, BlockPos position) {
         super.trigger(player, (conditions) -> {
-            return conditions.matches(event, world, position, listener);
+            return conditions.matches(event, world, position);
         });
     }
 
@@ -52,14 +50,11 @@ public class PlayerTriggerVibrationListener extends AbstractCriterion<PlayerTrig
         private final GameEventPredicate eventPredicate;
         @Nullable
         private final LocationPredicate locationPredicate;
-        @Nullable
-        private final EntityPredicate entityPredicate;
 
-        public Conditions(Identifier id, EntityPredicate.Extended player, @Nullable GameEventPredicate eventPredicate, @Nullable LocationPredicate locationPredicate, @Nullable EntityPredicate entityPredicate) {
+        public Conditions(Identifier id, EntityPredicate.Extended player, @Nullable GameEventPredicate eventPredicate, @Nullable LocationPredicate locationPredicate) {
             super(id, player);
             this.eventPredicate = eventPredicate;
             this.locationPredicate = locationPredicate;
-            this.entityPredicate = entityPredicate;
         }
 
         public JsonObject toJson(AdvancementEntityPredicateSerializer predicateSerializer) {
@@ -67,18 +62,14 @@ public class PlayerTriggerVibrationListener extends AbstractCriterion<PlayerTrig
             JsonElement eventJson = this.eventPredicate != null ? this.eventPredicate.toJson() : JsonNull.INSTANCE;
             json.add("event", eventJson);
             JsonElement locationJson = this.locationPredicate != null ? this.locationPredicate.toJson() : JsonNull.INSTANCE;
-            json.add("listener_block", locationJson);
-            JsonElement entityJson = this.entityPredicate != null ? this.entityPredicate.toJson() : JsonNull.INSTANCE;
-            json.add("listener_entity", entityJson);
+            json.add("listener", locationJson);
             return json;
         }
 
-        public boolean matches(GameEvent event, ServerWorld world, BlockPos position, @Nullable Entity listener) {
+        public boolean matches(GameEvent event, ServerWorld world, BlockPos position) {
             if (this.eventPredicate != null && !this.eventPredicate.test(event)) {
                 return false;
             } else if (this.locationPredicate != null && !this.locationPredicate.test(world, position.getX(), position.getY(), position.getZ())) {
-                return false;
-            } else if (this.entityPredicate != null && listener != null && !this.entityPredicate.test(world, listener.getPos(), listener)) {
                 return false;
             } else {
                 return true;

--- a/src/main/java/com/github/thedeathlycow/tdcdata/advancement/PlayerTriggerVibrationEntityListener.java
+++ b/src/main/java/com/github/thedeathlycow/tdcdata/advancement/PlayerTriggerVibrationEntityListener.java
@@ -1,0 +1,80 @@
+package com.github.thedeathlycow.tdcdata.advancement;
+
+import com.github.thedeathlycow.tdcdata.predicate.GameEventPredicate;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonNull;
+import com.google.gson.JsonObject;
+import net.minecraft.advancement.criterion.AbstractCriterion;
+import net.minecraft.advancement.criterion.AbstractCriterionConditions;
+import net.minecraft.entity.Entity;
+import net.minecraft.predicate.entity.AdvancementEntityPredicateDeserializer;
+import net.minecraft.predicate.entity.AdvancementEntityPredicateSerializer;
+import net.minecraft.predicate.entity.EntityPredicate;
+import net.minecraft.predicate.entity.LocationPredicate;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.event.GameEvent;
+import org.jetbrains.annotations.Nullable;
+
+public class PlayerTriggerVibrationEntityListener extends AbstractCriterion<PlayerTriggerVibrationEntityListener.Conditions> {
+
+    private final Identifier id;
+
+    public PlayerTriggerVibrationEntityListener(Identifier id) {
+        this.id = id;
+    }
+
+    @Override
+    protected Conditions conditionsFromJson(JsonObject json, EntityPredicate.Extended player, AdvancementEntityPredicateDeserializer predicateDeserializer) {
+        GameEventPredicate eventPredicate = GameEventPredicate.fromJson(json.get("event"));
+        EntityPredicate entityPredicate = EntityPredicate.fromJson(json.get("listener"));
+        return new Conditions(this.id, player, eventPredicate, entityPredicate);
+    }
+
+    public void trigger(ServerPlayerEntity player, GameEvent event, ServerWorld world, Entity entity) {
+        super.trigger(player, (conditions) -> {
+            return conditions.matches(event, world, entity);
+        });
+    }
+
+    @Override
+    public Identifier getId() {
+        return this.id;
+    }
+
+
+    public static class Conditions extends AbstractCriterionConditions {
+
+        @Nullable
+        private final GameEventPredicate eventPredicate;
+        @Nullable
+        private final EntityPredicate entityPredicate;
+
+        public Conditions(Identifier id, EntityPredicate.Extended entity, @Nullable GameEventPredicate eventPredicate, @Nullable EntityPredicate entityPredicate) {
+            super(id, entity);
+            this.eventPredicate = eventPredicate;
+            this.entityPredicate = entityPredicate;
+        }
+
+        public JsonObject toJson(AdvancementEntityPredicateSerializer predicateSerializer) {
+            JsonObject json = super.toJson(predicateSerializer);
+            JsonElement eventJson = this.eventPredicate != null ? this.eventPredicate.toJson() : JsonNull.INSTANCE;
+            json.add("event", eventJson);
+            JsonElement locationJson = this.entityPredicate != null ? this.entityPredicate.toJson() : JsonNull.INSTANCE;
+            json.add("listener", locationJson);
+            return json;
+        }
+
+        public boolean matches(GameEvent event, ServerWorld world, Entity entity) {
+            if (this.eventPredicate != null && !this.eventPredicate.test(event)) {
+                return false;
+            } else if (this.entityPredicate != null && !this.entityPredicate.test(world, entity.getPos(), entity)) {
+                return false;
+            } else {
+                return true;
+            }
+        }
+    }
+}

--- a/src/main/java/com/github/thedeathlycow/tdcdata/advancement/PlayerTriggerVibrationListener.java
+++ b/src/main/java/com/github/thedeathlycow/tdcdata/advancement/PlayerTriggerVibrationListener.java
@@ -13,6 +13,7 @@ import net.minecraft.predicate.entity.LocationPredicate;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.util.Identifier;
+import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.event.GameEvent;
 import org.jetbrains.annotations.Nullable;
@@ -32,7 +33,7 @@ public class PlayerTriggerVibrationListener extends AbstractCriterion<PlayerTrig
         return new Conditions(this.id, player, eventPredicate, block);
     }
 
-    public void trigger(ServerPlayerEntity player, GameEvent event, ServerWorld world, Vec3d position) {
+    public void trigger(ServerPlayerEntity player, GameEvent event, ServerWorld world, BlockPos position) {
         super.trigger(player, (conditions) -> {
             return conditions.matches(event, world, position);
         });
@@ -65,7 +66,7 @@ public class PlayerTriggerVibrationListener extends AbstractCriterion<PlayerTrig
             return json;
         }
 
-        public boolean matches(GameEvent event, ServerWorld world, Vec3d position) {
+        public boolean matches(GameEvent event, ServerWorld world, BlockPos position) {
             if (this.eventPredicate != null && !this.eventPredicate.test(event)) {
                 return false;
             } else if (this.block != null && !this.block.test(world, position.getX(), position.getY(), position.getZ())) {

--- a/src/main/java/com/github/thedeathlycow/tdcdata/advancement/PlayerTriggerVibrationListener.java
+++ b/src/main/java/com/github/thedeathlycow/tdcdata/advancement/PlayerTriggerVibrationListener.java
@@ -1,0 +1,78 @@
+package com.github.thedeathlycow.tdcdata.advancement;
+
+import com.github.thedeathlycow.tdcdata.predicate.GameEventPredicate;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonNull;
+import com.google.gson.JsonObject;
+import net.minecraft.advancement.criterion.AbstractCriterion;
+import net.minecraft.advancement.criterion.AbstractCriterionConditions;
+import net.minecraft.predicate.entity.AdvancementEntityPredicateDeserializer;
+import net.minecraft.predicate.entity.AdvancementEntityPredicateSerializer;
+import net.minecraft.predicate.entity.EntityPredicate;
+import net.minecraft.predicate.entity.LocationPredicate;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.math.Vec3d;
+import net.minecraft.world.event.GameEvent;
+import org.jetbrains.annotations.Nullable;
+
+public class PlayerTriggerVibrationListener extends AbstractCriterion<PlayerTriggerVibrationListener.Conditions> {
+
+    private final Identifier id;
+
+    public PlayerTriggerVibrationListener(Identifier id) {
+        this.id = id;
+    }
+
+    @Override
+    protected Conditions conditionsFromJson(JsonObject json, EntityPredicate.Extended player, AdvancementEntityPredicateDeserializer predicateDeserializer) {
+        GameEventPredicate eventPredicate = GameEventPredicate.fromJson(json.get("event"));
+        LocationPredicate block = LocationPredicate.fromJson(json.get("block"));
+        return new Conditions(this.id, player, eventPredicate, block);
+    }
+
+    public void trigger(ServerPlayerEntity player, GameEvent event, ServerWorld world, Vec3d position) {
+        super.trigger(player, (conditions) -> {
+            return conditions.matches(event, world, position);
+        });
+    }
+
+    @Override
+    public Identifier getId() {
+        return this.id;
+    }
+
+    public static class Conditions extends AbstractCriterionConditions {
+
+        @Nullable
+        private final GameEventPredicate eventPredicate;
+        @Nullable
+        private final LocationPredicate block;
+
+        public Conditions(Identifier id, EntityPredicate.Extended player, @Nullable GameEventPredicate eventPredicate, @Nullable LocationPredicate block) {
+            super(id, player);
+            this.eventPredicate = eventPredicate;
+            this.block = block;
+        }
+
+        public JsonObject toJson(AdvancementEntityPredicateSerializer predicateSerializer) {
+            JsonObject json = super.toJson(predicateSerializer);
+            JsonElement eventJson = this.eventPredicate != null ? this.eventPredicate.toJson() : JsonNull.INSTANCE;
+            json.add("event", eventJson);
+            JsonElement locationJson = this.block != null ? this.block.toJson() : JsonNull.INSTANCE;
+            json.add("block", locationJson);
+            return json;
+        }
+
+        public boolean matches(GameEvent event, ServerWorld world, Vec3d position) {
+            if (this.eventPredicate != null && !this.eventPredicate.test(event)) {
+                return false;
+            } else if (this.block != null && !this.block.test(world, position.getX(), position.getY(), position.getZ())) {
+                return false;
+            } else {
+                return true;
+            }
+        }
+    }
+}

--- a/src/main/java/com/github/thedeathlycow/tdcdata/advancement/PlayerTriggerVibrationListener.java
+++ b/src/main/java/com/github/thedeathlycow/tdcdata/advancement/PlayerTriggerVibrationListener.java
@@ -78,9 +78,7 @@ public class PlayerTriggerVibrationListener extends AbstractCriterion<PlayerTrig
                 return false;
             } else if (this.locationPredicate != null && !this.locationPredicate.test(world, position.getX(), position.getY(), position.getZ())) {
                 return false;
-            } else if (this.entityPredicate != null && listener == null) {
-                return false;
-            } else if (this.entityPredicate != null && !this.entityPredicate.test(world, listener.getPos(), listener)) {
+            } else if (this.entityPredicate != null && listener != null && !this.entityPredicate.test(world, listener.getPos(), listener)) {
                 return false;
             } else {
                 return true;

--- a/src/main/java/com/github/thedeathlycow/tdcdata/advancement/PlayerTriggerVibrationListener.java
+++ b/src/main/java/com/github/thedeathlycow/tdcdata/advancement/PlayerTriggerVibrationListener.java
@@ -1,5 +1,6 @@
 package com.github.thedeathlycow.tdcdata.advancement;
 
+import com.github.thedeathlycow.tdcdata.DatapackExtensions;
 import com.github.thedeathlycow.tdcdata.predicate.GameEventPredicate;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonNull;

--- a/src/main/java/com/github/thedeathlycow/tdcdata/advancement/TdcDataAdvancementTriggers.java
+++ b/src/main/java/com/github/thedeathlycow/tdcdata/advancement/TdcDataAdvancementTriggers.java
@@ -1,13 +1,17 @@
 package com.github.thedeathlycow.tdcdata.advancement;
 
+import com.github.thedeathlycow.tdcdata.DatapackExtensions;
 import net.minecraft.advancement.criterion.Criteria;
+import net.minecraft.util.Identifier;
 
 public class TdcDataAdvancementTriggers {
 
     public static final PlayerTriggerGameEventCriterion TRIGGER_VIBRATION = new PlayerTriggerGameEventCriterion();
+    public static final PlayerTriggerVibrationListener TRIGGER_SCULK_SENSOR = new PlayerTriggerVibrationListener(new Identifier(DatapackExtensions.MODID, "player_trigger_sculk_sensor"));
 
     public static void registerTriggers() {
         Criteria.register(TRIGGER_VIBRATION);
+        Criteria.register(TRIGGER_SCULK_SENSOR);
     }
 
 }

--- a/src/main/java/com/github/thedeathlycow/tdcdata/advancement/TdcDataAdvancementTriggers.java
+++ b/src/main/java/com/github/thedeathlycow/tdcdata/advancement/TdcDataAdvancementTriggers.java
@@ -8,10 +8,12 @@ public class TdcDataAdvancementTriggers {
 
     public static final PlayerTriggerGameEventCriterion TRIGGER_VIBRATION = new PlayerTriggerGameEventCriterion();
     public static final PlayerTriggerVibrationListener TRIGGER_SCULK_SENSOR = new PlayerTriggerVibrationListener(new Identifier(DatapackExtensions.MODID, "player_trigger_sculk_sensor"));
+    public static final PlayerTriggerVibrationListener TRIGGER_SCULK_SHRIEKER = new PlayerTriggerVibrationListener(new Identifier(DatapackExtensions.MODID, "player_trigger_sculk_shrieker"));
 
     public static void registerTriggers() {
         Criteria.register(TRIGGER_VIBRATION);
         Criteria.register(TRIGGER_SCULK_SENSOR);
+        Criteria.register(TRIGGER_SCULK_SHRIEKER);
     }
 
 }

--- a/src/main/java/com/github/thedeathlycow/tdcdata/advancement/TdcDataAdvancementTriggers.java
+++ b/src/main/java/com/github/thedeathlycow/tdcdata/advancement/TdcDataAdvancementTriggers.java
@@ -7,9 +7,9 @@ import net.minecraft.util.Identifier;
 public class TdcDataAdvancementTriggers {
 
     public static final PlayerTriggerGameEventCriterion TRIGGER_VIBRATION = new PlayerTriggerGameEventCriterion();
-    public static final PlayerTriggerVibrationListener PLAYER_TRIGGER_SCULK_SENSOR = new PlayerTriggerVibrationListener(new Identifier(DatapackExtensions.MODID, "player_trigger_sculk_sensor"));
-    public static final PlayerTriggerVibrationListener PLAYER_TRIGGER_SCULK_SHRIEKER = new PlayerTriggerVibrationListener(new Identifier(DatapackExtensions.MODID, "player_trigger_sculk_shrieker"));
-    public static final PlayerTriggerVibrationListener PLAYER_ALERTS_WARDEN = new PlayerTriggerVibrationListener(new Identifier(DatapackExtensions.MODID, "player_alerts_warden"));
+    public static final PlayerTriggerVibrationBlockListener PLAYER_TRIGGER_SCULK_SENSOR = new PlayerTriggerVibrationBlockListener(new Identifier(DatapackExtensions.MODID, "player_trigger_sculk_sensor"));
+    public static final PlayerTriggerVibrationBlockListener PLAYER_TRIGGER_SCULK_SHRIEKER = new PlayerTriggerVibrationBlockListener(new Identifier(DatapackExtensions.MODID, "player_trigger_sculk_shrieker"));
+    public static final PlayerTriggerVibrationEntityListener PLAYER_ALERTS_WARDEN = new PlayerTriggerVibrationEntityListener(new Identifier(DatapackExtensions.MODID, "player_alerts_warden"));
 
     public static void registerTriggers() {
         Criteria.register(TRIGGER_VIBRATION);

--- a/src/main/java/com/github/thedeathlycow/tdcdata/advancement/TdcDataAdvancementTriggers.java
+++ b/src/main/java/com/github/thedeathlycow/tdcdata/advancement/TdcDataAdvancementTriggers.java
@@ -7,13 +7,16 @@ import net.minecraft.util.Identifier;
 public class TdcDataAdvancementTriggers {
 
     public static final PlayerTriggerGameEventCriterion TRIGGER_VIBRATION = new PlayerTriggerGameEventCriterion();
-    public static final PlayerTriggerVibrationListener TRIGGER_SCULK_SENSOR = new PlayerTriggerVibrationListener(new Identifier(DatapackExtensions.MODID, "player_trigger_sculk_sensor"));
-    public static final PlayerTriggerVibrationListener TRIGGER_SCULK_SHRIEKER = new PlayerTriggerVibrationListener(new Identifier(DatapackExtensions.MODID, "player_trigger_sculk_shrieker"));
+    public static final PlayerTriggerVibrationListener PLAYER_TRIGGER_SCULK_SENSOR = new PlayerTriggerVibrationListener(new Identifier(DatapackExtensions.MODID, "player_trigger_sculk_sensor"));
+    public static final PlayerTriggerVibrationListener PLAYER_TRIGGER_SCULK_SHRIEKER = new PlayerTriggerVibrationListener(new Identifier(DatapackExtensions.MODID, "player_trigger_sculk_shrieker"));
+    public static final PlayerTriggerVibrationListener PLAYER_ALERTS_WARDEN = new PlayerTriggerVibrationListener(new Identifier(DatapackExtensions.MODID, "player_alerts_warden"));
 
     public static void registerTriggers() {
         Criteria.register(TRIGGER_VIBRATION);
-        Criteria.register(TRIGGER_SCULK_SENSOR);
-        Criteria.register(TRIGGER_SCULK_SHRIEKER);
+        Criteria.register(PLAYER_TRIGGER_SCULK_SENSOR);
+        Criteria.register(PLAYER_TRIGGER_SCULK_SHRIEKER);
+        Criteria.register(PLAYER_TRIGGER_SCULK_SHRIEKER);
+        Criteria.register(PLAYER_ALERTS_WARDEN);
     }
 
 }

--- a/src/main/java/com/github/thedeathlycow/tdcdata/advancement/TdcDataAdvancementTriggers.java
+++ b/src/main/java/com/github/thedeathlycow/tdcdata/advancement/TdcDataAdvancementTriggers.java
@@ -15,7 +15,6 @@ public class TdcDataAdvancementTriggers {
         Criteria.register(TRIGGER_VIBRATION);
         Criteria.register(PLAYER_TRIGGER_SCULK_SENSOR);
         Criteria.register(PLAYER_TRIGGER_SCULK_SHRIEKER);
-        Criteria.register(PLAYER_TRIGGER_SCULK_SHRIEKER);
         Criteria.register(PLAYER_ALERTS_WARDEN);
     }
 

--- a/src/main/java/com/github/thedeathlycow/tdcdata/mixin/advancement_triggers/TriggerGameEventCriterionMixin.java
+++ b/src/main/java/com/github/thedeathlycow/tdcdata/mixin/advancement_triggers/TriggerGameEventCriterionMixin.java
@@ -13,7 +13,7 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(ServerWorld.class)
-public class TriggerVibrationCriterionMixin {
+public class TriggerGameEventCriterionMixin {
 
     @Inject(
             method = "emitGameEvent",

--- a/src/main/java/com/github/thedeathlycow/tdcdata/mixin/advancement_triggers/TriggerGameEventCriterionMixin.java
+++ b/src/main/java/com/github/thedeathlycow/tdcdata/mixin/advancement_triggers/TriggerGameEventCriterionMixin.java
@@ -22,10 +22,6 @@ public class TriggerGameEventCriterionMixin {
     private void triggerVibrationCriterion(GameEvent event, Vec3d emitterPos, GameEvent.Emitter emitter, CallbackInfo ci) {
         Entity entity = emitter.sourceEntity();
         if (entity instanceof ServerPlayerEntity serverPlayer) {
-            int frequency = -1;
-            if (SculkSensorBlock.FREQUENCIES.containsKey(event)) {
-                frequency = SculkSensorBlock.FREQUENCIES.getInt(event);
-            }
             TdcDataAdvancementTriggers.TRIGGER_VIBRATION.trigger(serverPlayer, event);
         }
     }

--- a/src/main/java/com/github/thedeathlycow/tdcdata/mixin/advancement_triggers/TriggerSculkSensorCriterionMixin.java
+++ b/src/main/java/com/github/thedeathlycow/tdcdata/mixin/advancement_triggers/TriggerSculkSensorCriterionMixin.java
@@ -26,8 +26,8 @@ public class TriggerSculkSensorCriterionMixin {
                     target = "Lnet/minecraft/block/SculkSensorBlock;setActive(Lnet/minecraft/entity/Entity;Lnet/minecraft/world/World;Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/block/BlockState;I)V"
             )
     )
-    private static void triggerSculkSensorAdvancement(ServerWorld world, GameEventListener listener, BlockPos pos, GameEvent event, Entity entity, Entity sourceEntity, float distance, CallbackInfo ci) {
-        if (sourceEntity instanceof ServerPlayerEntity serverPlayer) {
+    private void triggerSculkSensorAdvancement(ServerWorld world, GameEventListener listener, BlockPos pos, GameEvent event, Entity entity, Entity sourceEntity, float distance, CallbackInfo ci) {
+        if (entity instanceof ServerPlayerEntity serverPlayer) {
             TdcDataAdvancementTriggers.TRIGGER_SCULK_SENSOR.trigger(serverPlayer, event, world, pos);
         }
     }

--- a/src/main/java/com/github/thedeathlycow/tdcdata/mixin/advancement_triggers/TriggerSculkSensorCriterionMixin.java
+++ b/src/main/java/com/github/thedeathlycow/tdcdata/mixin/advancement_triggers/TriggerSculkSensorCriterionMixin.java
@@ -1,14 +1,11 @@
 package com.github.thedeathlycow.tdcdata.mixin.advancement_triggers;
 
 import com.github.thedeathlycow.tdcdata.advancement.TdcDataAdvancementTriggers;
-import net.minecraft.block.BlockState;
-import net.minecraft.block.SculkSensorBlock;
 import net.minecraft.block.entity.SculkSensorBlockEntity;
 import net.minecraft.entity.Entity;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.util.math.BlockPos;
-import net.minecraft.world.World;
 import net.minecraft.world.event.GameEvent;
 import net.minecraft.world.event.listener.GameEventListener;
 import org.spongepowered.asm.mixin.Mixin;
@@ -28,7 +25,7 @@ public class TriggerSculkSensorCriterionMixin {
     )
     private void triggerSculkSensorAdvancement(ServerWorld world, GameEventListener listener, BlockPos pos, GameEvent event, Entity entity, Entity sourceEntity, float distance, CallbackInfo ci) {
         if (entity instanceof ServerPlayerEntity serverPlayer) {
-            TdcDataAdvancementTriggers.TRIGGER_SCULK_SENSOR.trigger(serverPlayer, event, world, pos);
+            TdcDataAdvancementTriggers.PLAYER_TRIGGER_SCULK_SENSOR.trigger(serverPlayer, event, world, pos, null);
         }
     }
 }

--- a/src/main/java/com/github/thedeathlycow/tdcdata/mixin/advancement_triggers/TriggerSculkSensorCriterionMixin.java
+++ b/src/main/java/com/github/thedeathlycow/tdcdata/mixin/advancement_triggers/TriggerSculkSensorCriterionMixin.java
@@ -25,7 +25,7 @@ public class TriggerSculkSensorCriterionMixin {
     )
     private void triggerSculkSensorAdvancement(ServerWorld world, GameEventListener listener, BlockPos pos, GameEvent event, Entity entity, Entity sourceEntity, float distance, CallbackInfo ci) {
         if (entity instanceof ServerPlayerEntity serverPlayer) {
-            TdcDataAdvancementTriggers.PLAYER_TRIGGER_SCULK_SENSOR.trigger(serverPlayer, event, world, pos, null);
+            TdcDataAdvancementTriggers.PLAYER_TRIGGER_SCULK_SENSOR.trigger(serverPlayer, event, world, pos);
         }
     }
 }

--- a/src/main/java/com/github/thedeathlycow/tdcdata/mixin/advancement_triggers/TriggerSculkSensorCriterionMixin.java
+++ b/src/main/java/com/github/thedeathlycow/tdcdata/mixin/advancement_triggers/TriggerSculkSensorCriterionMixin.java
@@ -1,0 +1,34 @@
+package com.github.thedeathlycow.tdcdata.mixin.advancement_triggers;
+
+import com.github.thedeathlycow.tdcdata.advancement.TdcDataAdvancementTriggers;
+import net.minecraft.block.BlockState;
+import net.minecraft.block.SculkSensorBlock;
+import net.minecraft.block.entity.SculkSensorBlockEntity;
+import net.minecraft.entity.Entity;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import net.minecraft.world.event.GameEvent;
+import net.minecraft.world.event.listener.GameEventListener;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(SculkSensorBlockEntity.class)
+public class TriggerSculkSensorCriterionMixin {
+
+    @Inject(
+            method = "accept",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/block/SculkSensorBlock;setActive(Lnet/minecraft/entity/Entity;Lnet/minecraft/world/World;Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/block/BlockState;I)V"
+            )
+    )
+    private static void triggerSculkSensorAdvancement(ServerWorld world, GameEventListener listener, BlockPos pos, GameEvent event, Entity entity, Entity sourceEntity, float distance, CallbackInfo ci) {
+        if (sourceEntity instanceof ServerPlayerEntity serverPlayer) {
+            TdcDataAdvancementTriggers.TRIGGER_SCULK_SENSOR.trigger(serverPlayer, event, world, pos);
+        }
+    }
+}

--- a/src/main/java/com/github/thedeathlycow/tdcdata/mixin/advancement_triggers/TriggerSculkSensorCriterionMixin.java
+++ b/src/main/java/com/github/thedeathlycow/tdcdata/mixin/advancement_triggers/TriggerSculkSensorCriterionMixin.java
@@ -1,6 +1,9 @@
 package com.github.thedeathlycow.tdcdata.mixin.advancement_triggers;
 
 import com.github.thedeathlycow.tdcdata.advancement.TdcDataAdvancementTriggers;
+import net.minecraft.block.BlockState;
+import net.minecraft.block.entity.BlockEntity;
+import net.minecraft.block.entity.BlockEntityType;
 import net.minecraft.block.entity.SculkSensorBlockEntity;
 import net.minecraft.entity.Entity;
 import net.minecraft.server.network.ServerPlayerEntity;
@@ -14,7 +17,11 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(SculkSensorBlockEntity.class)
-public class TriggerSculkSensorCriterionMixin {
+public class TriggerSculkSensorCriterionMixin extends BlockEntity {
+
+    public TriggerSculkSensorCriterionMixin(BlockEntityType<?> type, BlockPos pos, BlockState state) {
+        super(type, pos, state);
+    }
 
     @Inject(
             method = "accept",
@@ -25,7 +32,7 @@ public class TriggerSculkSensorCriterionMixin {
     )
     private void triggerSculkSensorAdvancement(ServerWorld world, GameEventListener listener, BlockPos pos, GameEvent event, Entity entity, Entity sourceEntity, float distance, CallbackInfo ci) {
         if (entity instanceof ServerPlayerEntity serverPlayer) {
-            TdcDataAdvancementTriggers.PLAYER_TRIGGER_SCULK_SENSOR.trigger(serverPlayer, event, world, pos);
+            TdcDataAdvancementTriggers.PLAYER_TRIGGER_SCULK_SENSOR.trigger(serverPlayer, event, world, this.getPos());
         }
     }
 }

--- a/src/main/java/com/github/thedeathlycow/tdcdata/mixin/advancement_triggers/TriggerSculkShriekerCriterionMixin.java
+++ b/src/main/java/com/github/thedeathlycow/tdcdata/mixin/advancement_triggers/TriggerSculkShriekerCriterionMixin.java
@@ -1,0 +1,34 @@
+package com.github.thedeathlycow.tdcdata.mixin.advancement_triggers;
+
+import com.github.thedeathlycow.tdcdata.DatapackExtensions;
+import com.github.thedeathlycow.tdcdata.advancement.TdcDataAdvancementTriggers;
+import net.minecraft.block.BlockState;
+import net.minecraft.block.entity.BlockEntity;
+import net.minecraft.block.entity.BlockEntityType;
+import net.minecraft.block.entity.SculkShriekerBlockEntity;
+import net.minecraft.entity.Entity;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.event.GameEvent;
+import net.minecraft.world.event.listener.GameEventListener;
+import org.jetbrains.annotations.Nullable;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(SculkShriekerBlockEntity.class)
+public class TriggerSculkShriekerCriterionMixin {
+
+    @Inject(
+            method = "accept",
+            at = @At("HEAD")
+    )
+    private void triggerSculkShriekerAdvancement(ServerWorld world, GameEventListener listener, BlockPos pos, GameEvent event, Entity entity, Entity sourceEntity, float distance, CallbackInfo ci) {
+        @Nullable ServerPlayerEntity player = SculkShriekerBlockEntity.findResponsiblePlayerFromEntity(sourceEntity != null ? sourceEntity : entity);
+        if (player != null) {
+            TdcDataAdvancementTriggers.TRIGGER_SCULK_SHRIEKER.trigger(player, event, world, pos);
+        }
+    }
+}

--- a/src/main/java/com/github/thedeathlycow/tdcdata/mixin/advancement_triggers/TriggerSculkShriekerCriterionMixin.java
+++ b/src/main/java/com/github/thedeathlycow/tdcdata/mixin/advancement_triggers/TriggerSculkShriekerCriterionMixin.java
@@ -1,10 +1,6 @@
 package com.github.thedeathlycow.tdcdata.mixin.advancement_triggers;
 
-import com.github.thedeathlycow.tdcdata.DatapackExtensions;
 import com.github.thedeathlycow.tdcdata.advancement.TdcDataAdvancementTriggers;
-import net.minecraft.block.BlockState;
-import net.minecraft.block.entity.BlockEntity;
-import net.minecraft.block.entity.BlockEntityType;
 import net.minecraft.block.entity.SculkShriekerBlockEntity;
 import net.minecraft.entity.Entity;
 import net.minecraft.server.network.ServerPlayerEntity;
@@ -28,7 +24,7 @@ public class TriggerSculkShriekerCriterionMixin {
     private void triggerSculkShriekerAdvancement(ServerWorld world, GameEventListener listener, BlockPos pos, GameEvent event, Entity entity, Entity sourceEntity, float distance, CallbackInfo ci) {
         @Nullable ServerPlayerEntity player = SculkShriekerBlockEntity.findResponsiblePlayerFromEntity(sourceEntity != null ? sourceEntity : entity);
         if (player != null) {
-            TdcDataAdvancementTriggers.TRIGGER_SCULK_SHRIEKER.trigger(player, event, world, pos);
+            TdcDataAdvancementTriggers.PLAYER_TRIGGER_SCULK_SHRIEKER.trigger(player, event, world, pos, null);
         }
     }
 }

--- a/src/main/java/com/github/thedeathlycow/tdcdata/mixin/advancement_triggers/TriggerSculkShriekerCriterionMixin.java
+++ b/src/main/java/com/github/thedeathlycow/tdcdata/mixin/advancement_triggers/TriggerSculkShriekerCriterionMixin.java
@@ -1,6 +1,9 @@
 package com.github.thedeathlycow.tdcdata.mixin.advancement_triggers;
 
 import com.github.thedeathlycow.tdcdata.advancement.TdcDataAdvancementTriggers;
+import net.minecraft.block.BlockState;
+import net.minecraft.block.entity.BlockEntity;
+import net.minecraft.block.entity.BlockEntityType;
 import net.minecraft.block.entity.SculkShriekerBlockEntity;
 import net.minecraft.entity.Entity;
 import net.minecraft.server.network.ServerPlayerEntity;
@@ -15,7 +18,11 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(SculkShriekerBlockEntity.class)
-public class TriggerSculkShriekerCriterionMixin {
+public class TriggerSculkShriekerCriterionMixin extends BlockEntity {
+
+    public TriggerSculkShriekerCriterionMixin(BlockEntityType<?> type, BlockPos pos, BlockState state) {
+        super(type, pos, state);
+    }
 
     @Inject(
             method = "accept",
@@ -24,7 +31,7 @@ public class TriggerSculkShriekerCriterionMixin {
     private void triggerSculkShriekerAdvancement(ServerWorld world, GameEventListener listener, BlockPos pos, GameEvent event, Entity entity, Entity sourceEntity, float distance, CallbackInfo ci) {
         @Nullable ServerPlayerEntity player = SculkShriekerBlockEntity.findResponsiblePlayerFromEntity(sourceEntity != null ? sourceEntity : entity);
         if (player != null) {
-            TdcDataAdvancementTriggers.PLAYER_TRIGGER_SCULK_SHRIEKER.trigger(player, event, world, pos);
+            TdcDataAdvancementTriggers.PLAYER_TRIGGER_SCULK_SHRIEKER.trigger(player, event, world, this.getPos());
         }
     }
 }

--- a/src/main/java/com/github/thedeathlycow/tdcdata/mixin/advancement_triggers/TriggerSculkShriekerCriterionMixin.java
+++ b/src/main/java/com/github/thedeathlycow/tdcdata/mixin/advancement_triggers/TriggerSculkShriekerCriterionMixin.java
@@ -24,7 +24,7 @@ public class TriggerSculkShriekerCriterionMixin {
     private void triggerSculkShriekerAdvancement(ServerWorld world, GameEventListener listener, BlockPos pos, GameEvent event, Entity entity, Entity sourceEntity, float distance, CallbackInfo ci) {
         @Nullable ServerPlayerEntity player = SculkShriekerBlockEntity.findResponsiblePlayerFromEntity(sourceEntity != null ? sourceEntity : entity);
         if (player != null) {
-            TdcDataAdvancementTriggers.PLAYER_TRIGGER_SCULK_SHRIEKER.trigger(player, event, world, pos, null);
+            TdcDataAdvancementTriggers.PLAYER_TRIGGER_SCULK_SHRIEKER.trigger(player, event, world, pos);
         }
     }
 }

--- a/src/main/java/com/github/thedeathlycow/tdcdata/mixin/advancement_triggers/TriggerWardenCriterionMixin.java
+++ b/src/main/java/com/github/thedeathlycow/tdcdata/mixin/advancement_triggers/TriggerWardenCriterionMixin.java
@@ -1,0 +1,32 @@
+package com.github.thedeathlycow.tdcdata.mixin.advancement_triggers;
+
+import com.github.thedeathlycow.tdcdata.advancement.TdcDataAdvancementTriggers;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.mob.WardenEntity;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.event.GameEvent;
+import net.minecraft.world.event.listener.GameEventListener;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(WardenEntity.class)
+public class TriggerWardenCriterionMixin {
+
+    @Inject(
+            method = "accept",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/entity/mob/WardenBrain;lookAtDisturbance(Lnet/minecraft/entity/mob/WardenEntity;Lnet/minecraft/util/math/BlockPos;)V"
+            )
+    )
+    private void triggerAlertWardenAdvancement(ServerWorld world, GameEventListener listener, BlockPos pos, GameEvent event, Entity entity, Entity sourceEntity, float distance, CallbackInfo ci) {
+        if (entity instanceof ServerPlayerEntity serverPlayer) {
+            final WardenEntity instance = (WardenEntity) (Object) this;
+            TdcDataAdvancementTriggers.PLAYER_ALERTS_WARDEN.trigger(serverPlayer, event, world, instance.getBlockPos(), instance);
+        }
+    }
+}

--- a/src/main/java/com/github/thedeathlycow/tdcdata/mixin/advancement_triggers/TriggerWardenCriterionMixin.java
+++ b/src/main/java/com/github/thedeathlycow/tdcdata/mixin/advancement_triggers/TriggerWardenCriterionMixin.java
@@ -26,7 +26,7 @@ public class TriggerWardenCriterionMixin {
     private void triggerAlertWardenAdvancement(ServerWorld world, GameEventListener listener, BlockPos pos, GameEvent event, Entity entity, Entity sourceEntity, float distance, CallbackInfo ci) {
         if (entity instanceof ServerPlayerEntity serverPlayer) {
             final WardenEntity instance = (WardenEntity) (Object) this;
-            TdcDataAdvancementTriggers.PLAYER_ALERTS_WARDEN.trigger(serverPlayer, event, world, instance.getBlockPos(), instance);
+            TdcDataAdvancementTriggers.PLAYER_ALERTS_WARDEN.trigger(serverPlayer, event, world, instance);
         }
     }
 }

--- a/src/main/resources/tdcdata.mixins.json
+++ b/src/main/resources/tdcdata.mixins.json
@@ -6,6 +6,7 @@
   "mixins": [
     "advancement_triggers.TriggerGameEventCriterionMixin",
     "advancement_triggers.TriggerSculkSensorCriterionMixin",
+    "advancement_triggers.TriggerSculkShriekerCriterionMixin",
     "command.ExecuteIfItemMixin",
     "command.ExecuteStoreAttributeCommandMixin",
     "command.argument.CustomArgRegistrationMixin",

--- a/src/main/resources/tdcdata.mixins.json
+++ b/src/main/resources/tdcdata.mixins.json
@@ -8,7 +8,7 @@
     "command.ExecuteStoreAttributeCommandMixin",
     "command.argument.CustomArgRegistrationMixin",
     "command.argument.CustomOperationMixin",
-    "advancement_triggers.TriggerVibrationCriterionMixin",
+    "advancement_triggers.TriggerGameEventCriterionMixin",
     "predicate.LightPredicateMixin",
     "scoreboard.teamrules.KeepInventoryOnDeathMixin",
     "scoreboard.teamrules.SerializeRulesMixin",

--- a/src/main/resources/tdcdata.mixins.json
+++ b/src/main/resources/tdcdata.mixins.json
@@ -7,6 +7,7 @@
     "advancement_triggers.TriggerGameEventCriterionMixin",
     "advancement_triggers.TriggerSculkSensorCriterionMixin",
     "advancement_triggers.TriggerSculkShriekerCriterionMixin",
+    "advancement_triggers.TriggerWardenCriterionMixin",
     "command.ExecuteIfItemMixin",
     "command.ExecuteStoreAttributeCommandMixin",
     "command.argument.CustomArgRegistrationMixin",

--- a/src/main/resources/tdcdata.mixins.json
+++ b/src/main/resources/tdcdata.mixins.json
@@ -4,11 +4,12 @@
   "package": "com.github.thedeathlycow.tdcdata.mixin",
   "compatibilityLevel": "JAVA_17",
   "mixins": [
+    "advancement_triggers.TriggerGameEventCriterionMixin",
+    "advancement_triggers.TriggerSculkSensorCriterionMixin",
     "command.ExecuteIfItemMixin",
     "command.ExecuteStoreAttributeCommandMixin",
     "command.argument.CustomArgRegistrationMixin",
     "command.argument.CustomOperationMixin",
-    "advancement_triggers.TriggerGameEventCriterionMixin",
     "predicate.LightPredicateMixin",
     "scoreboard.teamrules.KeepInventoryOnDeathMixin",
     "scoreboard.teamrules.SerializeRulesMixin",


### PR DESCRIPTION
Adds a number of criteria related to game events and sculk. 

* `tdcdata:player_trigger_game_event`: Triggered when a player triggers any game event. Can filter by event type, tag, and sculk sensor frequency
* `tdcdata:player_trigger_sculk_sensor`: Triggered when a player triggers a sculk sensor. Can filter by event type, tag, and sculk sensor frequency, and the location of the sculk sensor
* `tdcdata:player_trigger_sculk_shrieker`: Triggered when a player triggers a sculk shrieker. Can filter by event type, tag, and sculk sensor frequency, and the location of the sculk sensor
* `tdcdata:player_alerts_warden`: Triggered when a player alerts a Warden.  Can filter by event type, tag, and sculk sensor frequency, and the warden that was alerted 